### PR TITLE
[fix] fixed bootstrap header

### DIFF
--- a/src/sample/themes/default/templates/navbar/main.nix
+++ b/src/sample/themes/default/templates/navbar/main.nix
@@ -11,7 +11,7 @@
 { templates, lib, conf, navbar, ... }:
 with lib;
 ''
-<nav class="navbar navbar-fixed-top">
+<nav class="navbar navbar-default navbar-fixed-top">
   <div class="container">
 
     <div class="navbar-header">


### PR DESCRIPTION
Without this change, header background is transparent. When post is long and you have to use scroll, it looks like text overlap.

Taken from example at https://getbootstrap.com/examples/navbar-fixed-top/
