### PR TITLE
flakes support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1617661190,
+        "narHash": "sha256-yE1+gQ19t10FHWcZtdTc9H6W2jsT7SHCRXEMtWtcy+E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3211729b0bcfe79554f71854b8be8d0319b48b30",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1617631617,
+        "narHash": "sha256-PARRCz55qN3gy07VJZIlFeOX420d0nGF0RzGI/9hVlw=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b2c27d1a81b0dc266270fa8aeecebbd1807fc610",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "The purely functional static site generator in Nix expression language.";
+
+  inputs.utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, utils, nixpkgs, ... }: 
+    utils.lib.eachDefaultSystem (system: 
+      let
+        pkgs = import nixpkgs { inherit system; };
+        styx = pkgs.callPackage ./derivation.nix {};
+      in
+      {
+        packages = { inherit styx; };
+        defaultPackage = styx;
+
+        lib = import ./src/lib { inherit pkgs styx; };
+      }
+    );
+
+}

--- a/src/lib/default.nix
+++ b/src/lib/default.nix
@@ -1,7 +1,10 @@
-styx:
+# to allow for pure eval args can be
+# just styx or attrset with pkgs and styx
+args:
 let
   # For runCommand and writeText
-  nixpkgs = import <nixpkgs> {};
+  nixpkgs = if args ? pkgs then args.pkgs else import <nixpkgs> {};
+  styx = if args ? styx then args.styx else args;
 
   # nixpkgs lib
   base = nixpkgs.lib // builtins;


### PR DESCRIPTION
I tried to add flake support without changing too many things. The main issue is lib imports <nixpkgs> which is not allowed in pure eval, so I added a workaround that shouldn't break existing styx setups.

I'm not sure where to document this, but a styx user can now setup their site with a flake.nix. The `defaultPackage` can be a call to `lib.${system}.mkSite`, so the site an be built with `nix build` and maybe `defaultApp` could be styx, so you can use `nix run` to use the styx command.

With flakes enabled nix, and styx flake support you can do things like `nix shell github:styx-static/styx`.

flake.nix demonstration:
```nix
{
  inputs.utils.url = "github:numtide/flake-utils";
  inputs.styx.url = "github:styx-static/styx";

  outputs = { self, styx, utils, ... }:
    utils.eachDefaultSystem (system: 
      let
        lib = styx.lib.${system};
        themeData = ...;
        pageList = ...;
        inherit (themeData) files;        
      in
      {
        defaultPackage = lib.mkSite { inherit files pageList; }
      }
    );
}
```
Todo:
 - [ ] document flakes usage
 - [ ] flakes support to themes?
