### PR TITLE
Resolve symbolic links when generating site

### DIFF
--- a/src/lib/generation.nix
+++ b/src/lib/generation.nix
@@ -173,7 +173,7 @@ rec {
             if [ -d "$file" ]; then continue; fi
 
             # output path
-            path=$(realpath --relative-to="${filesDir}" "$file")
+            path=$(realpath -s --relative-to="${filesDir}" "$file")
             mkdir -p $(dirname $out/$path)
 
             if [ $(text_file $file) ]; then


### PR DESCRIPTION
Previously, when you had a symbolic link to some file on your computer that got passed to styx, it would just copy the link (which then obviously does not resolve). This makes the link get resolved by styx.