### PR TITLE
Use pandoc instead of multimarkdown

### DIFF
--- a/src/doc/data.adoc
+++ b/src/doc/data.adoc
@@ -82,7 +82,7 @@ The converted HTML will be in the `content` attribute of the data attribute set.
 
 TIP: It is possible to add extra data to a Markdown file by using <<Metadata>>.
 
-NOTE: link:http://fletcherpenney.net/multimarkdown/[MultiMarkdown] is used to convert Markdown.
+NOTE: link:http://pandoc.net/[Pandoc] is used to convert Markdown.
 
 ==== Nix
 

--- a/src/doc/data.adoc
+++ b/src/doc/data.adoc
@@ -82,7 +82,7 @@ The converted HTML will be in the `content` attribute of the data attribute set.
 
 TIP: It is possible to add extra data to a Markdown file by using <<Metadata>>.
 
-NOTE: link:http://pandoc.net/[Pandoc] is used to convert Markdown.
+NOTE: link:http://pandoc.org/[Pandoc] is used to convert Markdown.
 
 ==== Nix
 

--- a/src/styx-config.nix
+++ b/src/styx-config.nix
@@ -29,7 +29,7 @@
           description = "Supported extensions for markdown files.";
         };
         converter = lib.mkOption {
-          default = f: "${pkgs.multimarkdown}/bin/multimarkdown ${f} > $out";
+          default = f: "${pkgs.pandoc}/bin/pandoc ${f} > $out";
           type = with lib.types; functionTo str;
           description = "Command to convert asciidoc as a function that take the path of the file to convert as parameter.";
         };


### PR DESCRIPTION
This replaces multimarkdown with pandoc.

I've been patching out multimarkdown for pandoc for years now, and now that the new parser is merged the patch is even simpler.

I think pandoc is a better maintained and more modern than the other flavours of Markdown out there. It would also be quite easy to support other document formats with pandoc.
