### PR TITLE
link source in `share/styx-src` during install phase

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
 
     mkdir $themes
     cp -r themes/* $themes
+
+    ln -sT $src $out/share/styx-src
   '';
 
   meta = with lib; {


### PR DESCRIPTION
`styx preview-theme showcase` is broken on the current build:

```
$ nix-build
/nix/store/ycm9ybh4wgskj0z4m3f6m8vcc4gnqs2w-styx-0.7.5
$ /nix/store/ycm9ybh4wgskj0z4m3f6m8vcc4gnqs2w-styx-0.7.5/bin/styx preview-theme showcase
error: getting status of '/nix/store/ycm9ybh4wgskj0z4m3f6m8vcc4gnqs2w-styx-0.7.5/share/styx-src': No such file or directory
Please select an available theme, available themes are:
/nix/store/ycm9ybh4wgskj0z4m3f6m8vcc4gnqs2w-styx-0.7.5/bin/styx: line 418: /revs.csv: No such file or directory
```

This pull request fixes this by linking the the source code in `share/styx-src`.
