### PR TITLE
fix caddy flags

### DIFF
--- a/src/styx.sh
+++ b/src/styx.sh
@@ -534,13 +534,13 @@ if [ "$action" = serve ]; then
     path="$buildPath"
   fi
   if [ -n "$detachServer" ]; then
-    $server file-server -root \"$path\" -listen "$serverHost":"$port" >/dev/null &
+    $server file-server --root \"$path\" --listen "$serverHost":"$port" >/dev/null &
     serverPid=$!
     echo "server listening on http://$serverHost:$port with pid ${serverPid}"
   else
     echo "server listening on http://$serverHost:$port"
     echo "press Ctrl+C to stop"
-    $($server file-server -root "$path" -listen "$serverHost":"$port")
+    "$server" file-server --root "$path" --listen "$ServerHost":"$port"
   fi
 fi
 
@@ -561,7 +561,7 @@ if [ "$action" = linkcheck ]; then
   else
     path="$buildPath"
   fi
-  $server file-server -root \"$path\" -listen "$serverHost":"$port" >/dev/null &
+  $server file-server --root \"$path\" --listen "$serverHost":"$port" >/dev/null &
   serverPid=$!
   sleep 3
   echo "---"
@@ -590,7 +590,7 @@ if [ "$action" = live ]; then
     nix_error
   fi
   # start the server
-  $server file-server -root "$path" -listen "$serverHost":"$port" >/dev/null &
+  $server file-server --root "$path" --listen "$serverHost":"$port" >/dev/null &
   echo "Started live preview on http://$serverHost:$port"
   echo "Press q to quit"
   # saving the pid
@@ -609,7 +609,7 @@ if [ "$action" = live ]; then
         disown "$serverPid"
         kill -9 "$serverPid"
         # start the server
-        $server file-server -root "$path" -listen "$serverHost":"$port" >/dev/null &
+        $server file-server --root "$path" --listen "$serverHost":"$port" >/dev/null &
         echo "Done!"
         # updating the pid
         serverPid=$!


### PR DESCRIPTION

the caddy flags have been changed double `-` with a name

```
      --domain string   Domain name at which to serve the files
  -h, --help            help for file-server
      --listen string   The address to which to bind the listener
      --root string     The path to the root of the site
      --templates       Enable template rendering
```
